### PR TITLE
Adopt the new esp32 API (above 2.17) to use timer function

### DIFF
--- a/02-hardware-platforms/src/05_Watchdog/05_Watchdog.ino
+++ b/02-hardware-platforms/src/05_Watchdog/05_Watchdog.ino
@@ -1,34 +1,31 @@
 #include "esp_system.h"
 
 const int TIMEOUT_MS = 2000;
-const int TIMER_ID = 0;
-const int TIMER_DIVIDER = 80;
-const int TIMER_EDGE = true;
-const bool COUNT_UP = true;
-const int RESET = 0;
 
-hw_timer_t *timer = NULL;
+esp_timer_handle_t timer;
 
-
-void IRAM_ATTR timerTriggered() {
+void IRAM_ATTR timerTriggered(void* arg) {
   esp_restart();
 }
 
-
 void setup() {
-  
   Serial.begin(115200);
-  
-  timer = timerBegin(TIMER_ID, TIMER_DIVIDER, COUNT_UP);
-  timerAttachInterrupt(timer, &timerTriggered, TIMER_EDGE);
-  
-  timerAlarmWrite(timer, TIMEOUT_MS * 1000, false);
-  timerAlarmEnable(timer);
+
+  // Create a timer
+  const esp_timer_create_args_t timer_args = {
+    .callback = &timerTriggered,
+    .arg = NULL,
+    .name = "watchdog_timer"
+  };
+  esp_timer_create(&timer_args, &timer);
+
+  // Start the timer
+  esp_timer_start_once(timer, TIMEOUT_MS * 1000);
 }
 
 void loop() {
-  
   Serial.println("In main loop");
-  delay(TIMEOUT_MS *  2);
-  timerWrite(timer, RESET);
+  delay(TIMEOUT_MS * 2);
+  esp_timer_stop(timer);
+  esp_timer_start_once(timer, TIMEOUT_MS * 1000);
 }


### PR DESCRIPTION
To port the code to use the new Timer API in ESP version 3 and above, update the timerBegin function call and other related timer functions to match the new API is needed. The new API uses the esp_timer library instead of the old hw_timer library.